### PR TITLE
A first implementation of a MKMapView to display coordinates included in a Wikipedia article

### DIFF
--- a/Wikipedia.xcodeproj/project.pbxproj
+++ b/Wikipedia.xcodeproj/project.pbxproj
@@ -153,6 +153,9 @@
 		04F27B7B18FE19B700EDD838 /* PageHistoryOp.m in Sources */ = {isa = PBXBuildFile; fileRef = 04F27B7A18FE19B700EDD838 /* PageHistoryOp.m */; };
 		04F39590186CF80100B0D6FC /* TOCViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 04F3958F186CF80100B0D6FC /* TOCViewController.m */; };
 		04FD6C7A184EBFCD002CA02F /* ArticleData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 04FD6C78184EBFCD002CA02F /* ArticleData.xcdatamodeld */; };
+		AEC8E621197075A200DD85DD /* MapViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AEC8E61F197075A200DD85DD /* MapViewController.m */; };
+		AEC8E622197075A200DD85DD /* MapViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = AEC8E620197075A200DD85DD /* MapViewController.xib */; };
+		AEC8E6251970785A00DD85DD /* WikipediaLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEC8E6241970785A00DD85DD /* WikipediaLocation.m */; };
 		C9180EC418AED30C006C1DCA /* WikipediaAppUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = C9180EC318AED30C006C1DCA /* WikipediaAppUtils.m */; };
 		C958EE3418CE73E600148D13 /* DownloadTitlesForRandomArticlesOp.m in Sources */ = {isa = PBXBuildFile; fileRef = C958EE3318CE73E600148D13 /* DownloadTitlesForRandomArticlesOp.m */; };
 		C9928B8618AD5C6A00FCCA9A /* DownloadWikipediaZeroMessageOp.m in Sources */ = {isa = PBXBuildFile; fileRef = C9928B8518AD5C6A00FCCA9A /* DownloadWikipediaZeroMessageOp.m */; };
@@ -463,6 +466,11 @@
 		04F3958E186CF80100B0D6FC /* TOCViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TOCViewController.h; sourceTree = "<group>"; };
 		04F3958F186CF80100B0D6FC /* TOCViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TOCViewController.m; sourceTree = "<group>"; };
 		04FD6C79184EBFCD002CA02F /* ArticleData.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = ArticleData.xcdatamodel; sourceTree = "<group>"; };
+		AEC8E61E197075A200DD85DD /* MapViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MapViewController.h; path = MapView/MapViewController.h; sourceTree = "<group>"; };
+		AEC8E61F197075A200DD85DD /* MapViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MapViewController.m; path = MapView/MapViewController.m; sourceTree = "<group>"; };
+		AEC8E620197075A200DD85DD /* MapViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = MapViewController.xib; path = MapView/MapViewController.xib; sourceTree = "<group>"; };
+		AEC8E6231970785A00DD85DD /* WikipediaLocation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WikipediaLocation.h; path = MapView/WikipediaLocation.h; sourceTree = "<group>"; };
+		AEC8E6241970785A00DD85DD /* WikipediaLocation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = WikipediaLocation.m; path = MapView/WikipediaLocation.m; sourceTree = "<group>"; };
 		C9180EC218AED30C006C1DCA /* WikipediaAppUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WikipediaAppUtils.h; sourceTree = "<group>"; };
 		C9180EC318AED30C006C1DCA /* WikipediaAppUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WikipediaAppUtils.m; sourceTree = "<group>"; };
 		C958EE3218CE73E600148D13 /* DownloadTitlesForRandomArticlesOp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DownloadTitlesForRandomArticlesOp.h; sourceTree = "<group>"; };
@@ -1108,6 +1116,7 @@
 				0447861F185145090050563B /* History */,
 				041A3B5718E11ED90079FF1C /* Languages */,
 				0449E63218A9844000D51524 /* Login */,
+				AEC8E61D197074FC00DD85DD /* MapView */,
 				04530AF21935BF2900022512 /* ModalOverlay */,
 				042A5B1419253D2A0095E172 /* Navigation */,
 				04C91CE8195517030035ED1B /* Onboarding */,
@@ -1394,6 +1403,18 @@
 			path = TableOfContents;
 			sourceTree = "<group>";
 		};
+		AEC8E61D197074FC00DD85DD /* MapView */ = {
+			isa = PBXGroup;
+			children = (
+				AEC8E61E197075A200DD85DD /* MapViewController.h */,
+				AEC8E61F197075A200DD85DD /* MapViewController.m */,
+				AEC8E620197075A200DD85DD /* MapViewController.xib */,
+				AEC8E6231970785A00DD85DD /* WikipediaLocation.h */,
+				AEC8E6241970785A00DD85DD /* WikipediaLocation.m */,
+			);
+			name = MapView;
+			sourceTree = "<group>";
+		};
 		C9180EC118AED30C006C1DCA /* mw-utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -1602,7 +1623,7 @@
 				ORGANIZATIONNAME = "Wikimedia Foundation";
 				TargetAttributes = {
 					D4991434181D51DE00E6073C = {
-						DevelopmentTeam = D5RR3ZF62D;
+						DevelopmentTeam = SLUNTGN77L;
 					};
 				};
 			};
@@ -1724,6 +1745,7 @@
 				04082B5518ADA25A00FAF3D6 /* text_field_x_circle_gray@2x.png in Resources */,
 				0466F450183A30CC00EA1FD7 /* logo-search-placeholder@2x.png in Resources */,
 				04C91CF219554B310035ED1B /* logo-onboarding.png in Resources */,
+				AEC8E622197075A200DD85DD /* MapViewController.xib in Resources */,
 				045A9F0D18F6090E0057EA85 /* assets in Resources */,
 				04123638189C29EA00E0CF8E /* abuse-filter-flag-white@2x.png in Resources */,
 				04C91CEF195520990035ED1B /* logo-onboarding-subtitle@2x.png in Resources */,
@@ -1759,7 +1781,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "scripts/run-grunt.sh";
+			shellScript = "#scripts/run-grunt.sh";
 		};
 		D4C16A621970946900CD91AD /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1832,6 +1854,7 @@
 				04FD6C7A184EBFCD002CA02F /* ArticleData.xcdatamodeld in Sources */,
 				048A26771906268100395F53 /* PaddedLabel.m in Sources */,
 				C9928B8618AD5C6A00FCCA9A /* DownloadWikipediaZeroMessageOp.m in Sources */,
+				AEC8E621197075A200DD85DD /* MapViewController.m in Sources */,
 				04B91AAB18E3D9E200FFAA1C /* NSString+FormattedAttributedString.m in Sources */,
 				04735E6018A5B42D00C89C30 /* LoginTokenOp.m in Sources */,
 				043F18E518D9691D00D8489A /* UINavigationController+TopActionSheet.m in Sources */,
@@ -1933,6 +1956,7 @@
 				04CCCFEE1935093A00E3F60C /* SecondaryMenuRowView.m in Sources */,
 				0442F57B19006DCC00F55DF9 /* PageHistoryLabel.m in Sources */,
 				0447862F185145090050563B /* HistoryResultCell.m in Sources */,
+				AEC8E6251970785A00DD85DD /* WikipediaLocation.m in Sources */,
 				04B0EA45190AFDD8007458AF /* ArticleImporter.m in Sources */,
 				042A5B2619253D2A0095E172 /* CenterNavController.m in Sources */,
 				04B162F119284A6F00B1ABC2 /* BottomMenuContainerView.m in Sources */,

--- a/Wikipedia.xcodeproj/xcshareddata/xcschemes/Debug Wikipedia-iOS.xcscheme
+++ b/Wikipedia.xcodeproj/xcshareddata/xcschemes/Debug Wikipedia-iOS.xcscheme
@@ -74,21 +74,6 @@
          </CommandLineArgument>
       </CommandLineArguments>
       <AdditionalOptions>
-         <AdditionalOption
-            key = "MallocStackLogging"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "DYLD_INSERT_LIBRARIES"
-            value = "/usr/lib/libgmalloc.dylib"
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "NSZombieEnabled"
-            value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction

--- a/wikipedia/View Controllers/MapView/MapViewController.h
+++ b/wikipedia/View Controllers/MapView/MapViewController.h
@@ -1,0 +1,34 @@
+//
+//  MapViewController.h
+//  Wikipedia
+//
+//  Created by Ulf Buermeyer on 2014/07/11
+//  Copyright (c) 2014 Wikimedia Foundation.
+//  Provided under MIT-style license; please copy and modify!
+//
+
+#import <UIKit/UIKit.h>
+#import <MapKit/MapKit.h>
+#import <QuartzCore/QuartzCore.h>
+
+#import "WikipediaLocation.h"
+#import "WikiGlyphButton.h"
+#import "WikiGlyphLabel.h"
+#import "WikiGlyph_Chars.h"
+
+#define GEOHACK_URL_PREFIX      @"https://tools.wmflabs.org/geohack/geohack.php"
+#define WIKIPEDIA_ANNOTATION    @"WikipediaLocationAnnotation"
+
+@interface MapViewController : UIViewController <MKMapViewDelegate> {
+    // need ivars for properties that use custom getters / setters
+    NSString *_geohackURL;
+}
+
+@property IBOutlet MKMapView *map;
+@property IBOutlet WikiGlyphButton *dismissButton;
+@property IBOutlet WikiGlyphButton *mapStyleButton;
+@property IBOutlet WikiGlyphButton *geoHackButton;
+@property NSString *geohackURL;
+@property (readonly) WikipediaLocation *wikipediaLocation;
+
+@end

--- a/wikipedia/View Controllers/MapView/MapViewController.m
+++ b/wikipedia/View Controllers/MapView/MapViewController.m
@@ -1,0 +1,399 @@
+//
+//  MapViewController.m
+//  Wikipedia
+//
+//  Created by Ulf Buermeyer on 2014/07/11
+//  Copyright (c) 2014 Wikimedia Foundation.
+//  Provided under MIT-style license; please copy and modify!
+//
+
+#import "MapViewController.h"
+
+@interface MapViewController ()
+
+// may only be changed internally in order to assure sync with geohackURL
+@property (readwrite) WikipediaLocation *wikipediaLocation;
+
+@end
+
+
+@implementation MapViewController
+
+#pragma mark - custom getters / setters
+
+- (NSString *)geohackURL {
+    return _geohackURL;
+}
+
+
+- (void) setGeohackURL:(NSString *)geohackURL {
+
+    if ([geohackURL isEqualToString:_geohackURL]) {
+        // location unchanged
+        return;
+    }
+    
+    // ok, new location URL
+    
+    // store
+    _geohackURL = geohackURL;
+    
+    // delete old annotation, just in case
+    // we have to check if the anno's class is indeed WikipediaLocation as it might be MKUserLocation
+    // or some future Apple addition
+    NSArray *annotations = [self.map annotations];
+    for (id <MKAnnotation> anno in annotations) {
+        if ([anno isKindOfClass:[WikipediaLocation class]]) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.map removeAnnotation:anno];
+            });
+        }
+    } // end loop over annotations
+    
+    // retrieve coordinates & title string from geohack URL
+    // ex: https://tools.wmflabs.org/geohack/geohack.php?pagename=Coit_Tower&params=37_48_09_N_122_24_21_W_region:US-CA_type:landmark
+    NSLog(@"parsing geohack URL %@ ... ", geohackURL);
+    NSRange range = [geohackURL rangeOfString:GEOHACK_URL_PREFIX];
+    NSString *query = [geohackURL substringFromIndex:range.location + 1]; // add 1 to skip '?'
+    
+    // explode query parameters
+    NSArray *params = [query componentsSeparatedByString:@"&"];
+    
+    // zero-init fields for path components
+    NSString *pagename = @"";
+    CLLocationCoordinate2D coordinate = CLLocationCoordinate2DMake(CLLocationDistanceMax, CLLocationDistanceMax); // CLLocationDistanceMax = NaN for coordinates
+    
+    // loop over query params
+    for (NSString *param in params) {
+        
+        range = [param rangeOfString:@"pagename"];
+        if (range.location != NSNotFound) {
+            pagename = [param substringFromIndex:range.location + range.length + 1];
+            pagename = [self brushUpTitleString:pagename];
+            continue;
+        }
+
+        range = [param rangeOfString:@"params"];
+        if (range.location != NSNotFound) {
+            NSString *coordsString = [param substringFromIndex:range.location + range.length + 1];
+            coordinate = [self coordinateFromString:coordsString];
+        }
+        
+    } // end loop over query params
+    
+    NSLog(@"parsing URL completed, found pagename %@ & lng/lat %f / %f",
+          pagename, coordinate.longitude, coordinate.latitude);
+    
+    // valid coordinates? add annotation
+    if (CLLocationCoordinate2DIsValid(coordinate)) {
+        self.wikipediaLocation = [[WikipediaLocation alloc] initWithCoordinate:coordinate
+                                                                         title:pagename subtitle:nil];
+        
+        // this needs to be done on the main thread & we may be on any, who knows
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self displayAnnotation];
+        });
+    } // end valid coordinates
+    
+}
+
+
+// replace all _ by spaces, capitalize all words in title
+- (NSString *)brushUpTitleString:(NSString *)rawTitle {
+
+    NSArray *titleComponents = [rawTitle componentsSeparatedByString:@"_"];
+    NSString *newTitle = @"";
+    for (NSString *comp in titleComponents) {
+        NSString *firstChar = [comp substringToIndex:1];
+        NSString *tail = [comp substringFromIndex:1];
+        firstChar = [firstChar uppercaseString];
+        if([newTitle length] > 0) {
+            // already word in title? prepend by space
+            newTitle = [newTitle stringByAppendingString:@" "];
+        }
+        newTitle = [newTitle stringByAppendingString:firstChar];
+        // tail might be nil if a title comp is only one character
+        if(tail) {
+            newTitle = [newTitle stringByAppendingString:tail];
+        }
+    }
+
+    return newTitle;
+}
+
+
+- (CLLocationCoordinate2D) coordinateFromString:(NSString *)string {
+
+    // "NaN" - init coordinates
+    CLLocationDegrees lng = CLLocationDistanceMax;
+    CLLocationDegrees lat = CLLocationDistanceMax;
+    
+    // loop over components of coordinate string
+    NSArray *components = [string componentsSeparatedByString:@"_"];
+    int step = 0;
+    CLLocationDegrees buffer;
+    
+    for (NSString *comp in components) {
+        CLLocationDegrees value = [comp floatValue];
+        
+        // numerical value?
+        // TODO: this fails for coordinates including lng or lat of exactly 0.0 - should be caught
+        if (value != 0.0) {
+            if (step == 0) {
+                // degrees
+                buffer = value;
+                step++;
+                continue;
+            }
+            else if (step == 1) {
+                // minutes
+                buffer += (value / 60.0);
+                step++;
+                continue;
+            }
+            else if (step == 2) {
+                // seconds
+                buffer += (value / 3600.0);
+                continue;
+            }
+        } // end comp represents a number
+        
+        // no number? ok, NSWE chars
+        // -> move buffer to appropriate coordinate variable (lng, lat) and set sign +/-
+        if ([comp isEqualToString:@"N"]) {
+            lat = buffer;
+            buffer = 0.0;
+            step = 0;
+            continue;
+        }
+        if ([comp isEqualToString:@"S"]) {
+            lat = -buffer;
+            buffer = 0.0;
+            step = 0;
+            continue;
+        }
+        if ([comp isEqualToString:@"E"]) {
+            lng = buffer;
+            buffer = 0.0;
+            step = 0;
+            continue;
+        }
+        if ([comp isEqualToString:@"W"]) {
+            lng = -buffer;
+            buffer = 0.0;
+            step = 0;
+            continue;
+        }
+        
+    } // end loop over params components
+    
+    // check results
+    if (lng != CLLocationDistanceMax && lat != CLLocationDistanceMax) {
+        // both set to valid values
+        return CLLocationCoordinate2DMake(lat, lng);
+    }
+    
+    // parsing failed: return invalid coordinate
+    return CLLocationCoordinate2DMake(CLLocationDistanceMax, CLLocationDistanceMax);
+
+}
+
+
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
+{
+    self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+    if (self) {
+        // Custom initialization
+    }
+    return self;
+}
+
+
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
+    
+    // iOS 7 tweaks
+    if ([self respondsToSelector:@selector(edgesForExtendedLayout)]) {
+        self.edgesForExtendedLayout = UIRectEdgeNone;
+        self.navigationController.navigationBar.tintColor = [UIColor darkGrayColor];
+    }
+    
+    // basic map config
+    self.map.showsUserLocation = NO;
+    self.map.delegate = self;
+    self.map.mapType = MKMapTypeStandard;
+    
+    // set map region to display BEFORE zooming in on pin
+    // but only if wikipedia location is not yet set
+    if (!self.wikipediaLocation) {
+        CLLocationCoordinate2D center = CLLocationCoordinate2DMake(0.0, 0.0);
+        MKCoordinateSpan worldSpan = MKCoordinateSpanMake(90.0, 180.0);
+        MKCoordinateRegion region = MKCoordinateRegionMake(center, worldSpan);
+        [self.map setRegion:region animated:NO];
+    }
+    
+    // config buttons
+    CGFloat size = 34;
+    CGFloat baselineOffset = 2.0;
+
+    // dismiss button
+    [self.dismissButton.label setWikiText:WIKIGLYPH_X
+                                    color:[UIColor blackColor]
+                                     size:size
+                           baselineOffset:baselineOffset];
+    self.dismissButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.dismissButton.enabled = YES;
+    [self.dismissButton addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget: self
+                                                                         action: @selector(dismissButtonPushed:)]];
+    // map style button
+    [self.mapStyleButton.label setWikiText:WIKIGLYPH_GEAR
+                                    color:[UIColor blackColor]
+                                     size:size
+                           baselineOffset:baselineOffset];
+    self.mapStyleButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.mapStyleButton.enabled = YES;
+    [self.mapStyleButton addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget: self
+                                                                                     action: @selector(mapStyleButtonPushed:)]];
+    
+    // geohack button
+    [self.geoHackButton.label setWikiText:WIKIGLYPH_SHARE
+                                     color:[UIColor blackColor]
+                                      size:size
+                            baselineOffset:baselineOffset];
+    self.geoHackButton.translatesAutoresizingMaskIntoConstraints = NO;
+    self.geoHackButton.enabled = YES;
+    [self.geoHackButton addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget: self
+                                                                                     action: @selector(geoHackButtonPushed:)]];
+}
+
+
+- (void) viewDidAppear:(BOOL)animated {
+
+    [super viewDidAppear:animated];
+    
+}
+
+
+#pragma mark annotation handling
+- (MKAnnotationView *)mapView:(MKMapView *)mapView viewForAnnotation:(id < MKAnnotation >)annotation {
+    
+    // check if the view is requested for the only supported annotation, realEstate
+    if (![annotation isKindOfClass:[WikipediaLocation class]]) {
+        NSLog(@"view for unsupported annotation of class %@ requested",
+              NSStringFromClass([annotation class]));
+        return nil;
+    }
+
+    MKPinAnnotationView *pv = [[MKPinAnnotationView alloc] initWithAnnotation:annotation
+                                                              reuseIdentifier:WIKIPEDIA_ANNOTATION];
+    pv.draggable = NO;
+    pv.animatesDrop = YES;
+    pv.enabled = YES;
+    pv.canShowCallout = YES;
+
+    // icon
+    UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0,0, 30, 30)];
+    imageView.image = [UIImage imageNamed:@"logo-search-placeholder.png"];
+    imageView.contentMode = UIViewContentModeScaleAspectFit;
+    
+    // add rounded corners to annotation icon
+    /*
+    imageView.layer.cornerRadius = 3;
+    imageView.layer.masksToBounds = YES;
+    imageView.layer.borderColor = [UIColor lightGrayColor].CGColor;
+    imageView.layer.borderWidth = 1;
+     */
+
+    // add accessory view = image to callout
+    pv.leftCalloutAccessoryView = imageView;
+
+    return pv;
+}
+
+
+// once self.wikipediaLocation is set, add it as an annotation & zoom in on it
+- (void) displayAnnotation {
+    
+    NSLog(@"displaying self.wikipediaLocation: %@", self.wikipediaLocation);
+    
+    NSAssert(self.wikipediaLocation, @"self.wikipediaLocation must be set to be displayed");
+    if (!self.wikipediaLocation) {
+        return;
+    }
+    
+    // choose map region
+    CLLocationCoordinate2D center = self.wikipediaLocation.coordinate;
+    MKCoordinateRegion region = MKCoordinateRegionMakeWithDistance(center,
+                                                                   1000,
+                                                                   1000);     // span in meters
+    [self.map setRegion:region animated:YES];
+    
+    // add annotation
+    [self.map addAnnotation:self.wikipediaLocation];
+    
+    // select it
+    [self.map selectAnnotation:self.wikipediaLocation animated:YES];
+    
+    // show user location as well
+    [self.map setShowsUserLocation:YES];
+    
+}
+
+#pragma mark - button actions
+
+- (IBAction)dismissButtonPushed:(id)sender {
+
+    NSLog(@"dismissButtonPushed");
+    
+    [self.presentingViewController dismissViewControllerAnimated:YES
+                                                      completion:nil];
+
+}
+
+
+- (IBAction)geoHackButtonPushed:(id)sender {
+    
+    NSLog(@"geoHackButtonPushed");
+    
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:self.geohackURL]];
+    
+}
+
+
+- (IBAction)mapStyleButtonPushed:(id)sender {
+    
+    NSLog(@"mapStyleButtonPushed");
+    
+    [self toggleMapStyle];
+    
+}
+
+
+- (void) toggleMapStyle {
+
+    MKMapType mapType = self.map.mapType;
+    MKMapType newMapType;
+    
+    switch (mapType) {
+        case MKMapTypeStandard:
+            newMapType = MKMapTypeHybrid;
+            break;
+        case MKMapTypeHybrid:
+            newMapType = MKMapTypeSatellite;
+            break;
+        default:
+            newMapType = MKMapTypeStandard;
+            break;
+    }
+    
+    self.map.mapType = newMapType;
+
+}
+
+
+
+
+
+@end

--- a/wikipedia/View Controllers/MapView/MapViewController.xib
+++ b/wikipedia/View Controllers/MapView/MapViewController.xib
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment defaultVersion="1536" identifier="iOS"/>
+        <development version="5000" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MapViewController">
+            <connections>
+                <outlet property="dismissButton" destination="VYb-gt-hKT" id="Fdl-tl-X2q"/>
+                <outlet property="geoHackButton" destination="raj-Te-7K7" id="rSL-sP-1h2"/>
+                <outlet property="map" destination="25" id="DZR-vE-KKg"/>
+                <outlet property="mapStyleButton" destination="NMm-qd-LEy" id="L0L-pc-Wij"/>
+                <outlet property="view" destination="1" id="SMR-0k-WfU"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view autoresizesSubviews="NO" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ivC-ik-YKy" userLabel="Bottom Menu Container" customClass="BottomMenuContainerView">
+                    <rect key="frame" x="0.0" y="20" width="320" height="40"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VYb-gt-hKT" customClass="WikiGlyphButton">
+                            <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="40" id="pdw-Ih-m1C"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NMm-qd-LEy" customClass="WikiGlyphButton">
+                            <rect key="frame" x="75" y="0.0" width="40" height="40"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="40" id="vnH-EW-QQd"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="raj-Te-7K7" customClass="WikiGlyphButton">
+                            <rect key="frame" x="273" y="0.0" width="40" height="40"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="40" id="tTY-ic-xQo"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <constraints>
+                        <constraint firstItem="raj-Te-7K7" firstAttribute="top" secondItem="ivC-ik-YKy" secondAttribute="top" id="JcI-mB-JlJ"/>
+                        <constraint firstAttribute="bottom" secondItem="raj-Te-7K7" secondAttribute="bottom" id="MTU-jh-6G7"/>
+                        <constraint firstItem="NMm-qd-LEy" firstAttribute="top" secondItem="ivC-ik-YKy" secondAttribute="top" id="YVA-w1-d2u"/>
+                        <constraint firstAttribute="trailing" secondItem="raj-Te-7K7" secondAttribute="trailing" constant="7" id="ice-Hb-Got"/>
+                        <constraint firstAttribute="bottom" secondItem="NMm-qd-LEy" secondAttribute="bottom" id="lJ0-Oj-1kY"/>
+                        <constraint firstItem="NMm-qd-LEy" firstAttribute="leading" secondItem="VYb-gt-hKT" secondAttribute="trailing" constant="35" id="nzx-Ub-zhi"/>
+                        <constraint firstItem="VYb-gt-hKT" firstAttribute="top" secondItem="ivC-ik-YKy" secondAttribute="top" id="sSd-4e-iCl"/>
+                        <constraint firstAttribute="bottom" secondItem="VYb-gt-hKT" secondAttribute="bottom" id="szP-La-3bM"/>
+                        <constraint firstItem="VYb-gt-hKT" firstAttribute="leading" secondItem="ivC-ik-YKy" secondAttribute="leading" id="xT8-0P-q7N"/>
+                        <constraint firstAttribute="height" constant="40" id="zdF-0x-C62"/>
+                    </constraints>
+                </view>
+                <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="25">
+                    <rect key="frame" x="0.0" y="60" width="320" height="420"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                </mapView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="ivC-ik-YKy" secondAttribute="trailing" id="7Pg-gO-mUg"/>
+                <constraint firstItem="ivC-ik-YKy" firstAttribute="bottom" secondItem="25" secondAttribute="top" id="QKd-52-b6k"/>
+                <constraint firstItem="ivC-ik-YKy" firstAttribute="top" secondItem="1" secondAttribute="top" constant="20" id="SpL-Qw-jud"/>
+                <constraint firstAttribute="trailing" secondItem="25" secondAttribute="trailing" id="eBr-VE-WwF"/>
+                <constraint firstItem="25" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="oX4-on-CMY"/>
+                <constraint firstItem="ivC-ik-YKy" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="stW-T2-zIQ"/>
+                <constraint firstAttribute="bottom" secondItem="25" secondAttribute="bottom" id="tZe-gu-uFB"/>
+            </constraints>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="blackOpaque"/>
+        </view>
+    </objects>
+</document>

--- a/wikipedia/View Controllers/MapView/WikipediaLocation.h
+++ b/wikipedia/View Controllers/MapView/WikipediaLocation.h
@@ -1,0 +1,23 @@
+//
+//  WikipediaLocation.h
+//  Wikipedia
+//
+//  Created by Ulf Buermeyer on 7/11/14.
+//  Copyright (c) 2014 Wikimedia Foundation.
+//  Provided under MIT-style license; please copy and modify!
+//
+
+#import <MapKit/MapKit.h>
+#import <Foundation/Foundation.h>
+
+@interface WikipediaLocation : NSObject <MKAnnotation>
+
+@property (nonatomic, readonly) CLLocationCoordinate2D coordinate;
+@property (nonatomic, readonly, copy) NSString *subtitle;
+@property (nonatomic, readonly, copy) NSString *title;
+
+- (id)initWithCoordinate:(CLLocationCoordinate2D)coordinate
+                   title:(NSString *)title
+                subtitle:(NSString *)subtitle;
+
+@end

--- a/wikipedia/View Controllers/MapView/WikipediaLocation.m
+++ b/wikipedia/View Controllers/MapView/WikipediaLocation.m
@@ -1,0 +1,32 @@
+//
+//  WikipediaLocation.m
+//  Wikipedia
+//
+//  Created by Ulf Buermeyer on 7/11/14.
+//  Copyright (c) 2014 Wikimedia Foundation.
+//  Provided under MIT-style license; please copy and modify!
+//
+
+#import "WikipediaLocation.h"
+
+@implementation WikipediaLocation 
+
+
+- (id)initWithCoordinate:(CLLocationCoordinate2D)coordinate
+                   title:(NSString *)title
+                subtitle:(NSString *)subtitle {
+
+    // coordinate is the only required property,
+    // see https://developer.apple.com/library/ios/documentation/MapKit/Reference/MKAnnotation_Protocol/Reference/Reference.html
+    if (CLLocationCoordinate2DIsValid(coordinate)) {
+        _coordinate = coordinate;
+        _title = title;
+        _subtitle = subtitle;
+        return self;
+    }
+    
+    return nil;
+}
+
+
+@end

--- a/wikipedia/View Controllers/WebView/WebViewController.h
+++ b/wikipedia/View Controllers/WebView/WebViewController.h
@@ -6,6 +6,7 @@
 #import "CenterNavController.h"
 #import "MWPageTitle.h"
 #import "PullToRefreshViewController.h"
+#import "MapViewController.h"
 
 @interface WebViewController : PullToRefreshViewController <UIWebViewDelegate, NetworkOpDelegate, UIScrollViewDelegate, UIGestureRecognizerDelegate, UIAlertViewDelegate>
 

--- a/wikipedia/View Controllers/WebView/WebViewController.m
+++ b/wikipedia/View Controllers/WebView/WebViewController.m
@@ -810,6 +810,26 @@ typedef enum {
                 href = [@"https:" stringByAppendingString:href];
             }
             
+            // check if this is a link to a geocoordinate
+            // if so, launch map view rather than geohack table of map options
+            if ([href hasPrefix:GEOHACK_URL_PREFIX]) {
+                // launch map view
+                NSLog(@"detected tap on geohack link - showing map view");
+                MapViewController *mapVC;
+                mapVC = [[MapViewController alloc] initWithNibName:nil bundle:nil];
+                if (mapVC) {
+                    [mapVC setGeohackURL:href];
+                    [weakSelf presentViewController:mapVC
+                                       animated:YES
+                                     completion:^{
+                                         NSLog(@"map view controller displayed");
+                                     }];
+                }
+                
+                // done; do not open geohack page in Safari (yet)
+                return;
+            }
+            
             // TODO: make all of the stuff above parse the URL into parts
             // unless it's /wiki/ or #anchor style.
             // Then validate if it's still in Wikipedia land and branch appropriately.


### PR DESCRIPTION
At this stage the implementation catches taps onto geohack extension links, launches a MapViewController and passes the geohack URL on to the MVC.

The MapViewController parses the URL, gathers coordinates and title and displays a native iOS map with an annotation (“pin”) representing the article in question. The map style can be toggled by tapping the gear. Tapping the “Share”-Button opens the geohack page in MobileSafari.

Next steps: use geo api JSON call to retrieve coordinates already while loading article, add map icon to bottom toolbar in main article view if coordinates associated with article can be retrieved.

By Ulf Buermeyer, @if0xx.