### PR TITLE
MWPageTitle: added property allCapsText

### DIFF
--- a/wikipedia/mw-support/MWPageTitle.h
+++ b/wikipedia/mw-support/MWPageTitle.h
@@ -33,6 +33,11 @@
 @property (readonly) NSString *text;
 
 /**
+ * Normalized title component only (decoded, no underscores, all words capitalized)
+ */
+@property (readonly) NSString *allCapsText;
+
+/**
  * Fragment (component after the '#')
  * Warning: fragment may be nil!
  */

--- a/wikipedia/mw-support/MWPageTitle.m
+++ b/wikipedia/mw-support/MWPageTitle.m
@@ -53,6 +53,11 @@
     return _text;
 }
 
+-(NSString *)allCapsText {
+
+    return [_text capitalizedStringWithLocale:[NSLocale currentLocale]];
+}
+
 -(NSString *)fragment
 {
     return _fragment;


### PR DESCRIPTION
added a new readonly property 'allCapsText' to MWPageTitle that is guaranteed to return an all-caps title string using [NSString capitalizedStringWithLocale:]